### PR TITLE
Minor formatting fixes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -82,8 +82,8 @@
             ln -sf ${pdutil}/bin/pdutil $HOME/playdatesdk-${version}/bin/pdutil
             ln -sf ${PlaydateSimulatorWrapped}/bin/PlaydateSimulator $HOME/playdatesdk-${version}/bin/PlaydateSimulator
             printf "\nInstalled PlaydateSDK to $HOME/playdatesdk-${version}!\n"
-            fi
-            if ! [[ -d "$HOME/.Playdate Simulator/" ]]; then
+          fi
+          if ! [[ -d "$HOME/.Playdate Simulator/" ]]; then
             printf "Playdate Simulator config not found, configuring $HOME/.Playdate Simulator/Playdate Simulator.ini to use the Playdate SDK..."
             mkdir $HOME/.Playdate\ Simulator/
             echo "SDKDirectory=$HOME/playdatesdk-${version}" >> "$HOME/.Playdate Simulator/Playdate Simulator.ini"
@@ -101,6 +101,4 @@
       packages.x86_64-linux.PlaydateSimulator = PlaydateSimulatorWrapped;
       defaultPackage.x86_64-linux = shell;
     };
-
 }
-

--- a/flake.nix
+++ b/flake.nix
@@ -36,8 +36,8 @@
 
         buildInputs = [ pkgs.zlib pkgs.libpng ];
         installPhase = ''
-                    tar xfz $src
-                    mkdir -p $out/bin
+          tar xfz $src
+          mkdir -p $out/bin
           cp -r PlaydateSDK-${version}/bin/pdutil $out/bin/pdutil
         '';
         sourceRoot = ".";
@@ -72,25 +72,25 @@
       };
       shell = pkgs.mkShell {
         shellHook = ''
-        printf "Configuring shell...\n"
-        if ! [[ -d $HOME/playdatesdk-${version} ]]; then
-                          printf "Playdate SDK not found, installing PlaydateSDK to $HOME/playdatesdk-${version}"
-                          tar -xzf ${playdateSDK}
-                          mkdir $HOME/playdatesdk-${version}
-                          mv PlaydateSDK-${version}/* $HOME/playdatesdk-${version}
-                          ln -sf ${pdc}/bin/pdc $HOME/playdatesdk-${version}/bin/pdc
-                          ln -sf ${pdutil}/bin/pdutil $HOME/playdatesdk-${version}/bin/pdutil
-                          ln -sf ${PlaydateSimulatorWrapped}/bin/PlaydateSimulator $HOME/playdatesdk-${version}/bin/PlaydateSimulator
-                          printf "\nInstalled PlaydateSDK to $HOME/playdatesdk-${version}!\n"
-                          fi
-                          if ! [[ -d "$HOME/.Playdate Simulator/" ]]; then
-                          printf "Playdate Simulator config not found, configuring $HOME/.Playdate Simulator/Playdate Simulator.ini to use the Playdate SDK..."
-                          mkdir $HOME/.Playdate\ Simulator/
-                          echo "SDKDirectory=$HOME/playdatesdk-${version}" >> "$HOME/.Playdate Simulator/Playdate Simulator.ini"
-                          printf "\nConfigured Playdate Simulator!\n"
+          printf "Configuring shell...\n"
+          if ! [[ -d $HOME/playdatesdk-${version} ]]; then
+            printf "Playdate SDK not found, installing PlaydateSDK to $HOME/playdatesdk-${version}"
+            tar -xzf ${playdateSDK}
+            mkdir $HOME/playdatesdk-${version}
+            mv PlaydateSDK-${version}/* $HOME/playdatesdk-${version}
+            ln -sf ${pdc}/bin/pdc $HOME/playdatesdk-${version}/bin/pdc
+            ln -sf ${pdutil}/bin/pdutil $HOME/playdatesdk-${version}/bin/pdutil
+            ln -sf ${PlaydateSimulatorWrapped}/bin/PlaydateSimulator $HOME/playdatesdk-${version}/bin/PlaydateSimulator
+            printf "\nInstalled PlaydateSDK to $HOME/playdatesdk-${version}!\n"
+            fi
+            if ! [[ -d "$HOME/.Playdate Simulator/" ]]; then
+            printf "Playdate Simulator config not found, configuring $HOME/.Playdate Simulator/Playdate Simulator.ini to use the Playdate SDK..."
+            mkdir $HOME/.Playdate\ Simulator/
+            echo "SDKDirectory=$HOME/playdatesdk-${version}" >> "$HOME/.Playdate Simulator/Playdate Simulator.ini"
+            printf "\nConfigured Playdate Simulator!\n"
           fi
-                          export PLAYDATE_SDK_PATH=$HOME/playdatesdk-${version}
-        printf "Finished configuring, you are ready to go!"
+          export PLAYDATE_SDK_PATH=$HOME/playdatesdk-${version}
+          printf "Finished configuring, you are ready to go!\n"
         '';
         packages = [ PlaydateSimulatorWrapped pdc pdutil ];
       };

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
         url = "https://download.panic.com/playdate_sdk/Linux/PlaydateSDK-${version}.tar.gz";
         sha256 = "FNzb3OjXGZpTTuR9+ox9KZD0sKlYfoA7jg48lZeQrpE=";
       };
-      pdc = stdenv.mkDerivation rec {
+      pdc = stdenv.mkDerivation {
         name = "pdc-${version}";
         src = playdateSDK;
         nativeBuildInputs = [ autoPatchelfHook ];
@@ -29,7 +29,7 @@
           platforms = platforms.linux;
         };
       };
-      pdutil = stdenv.mkDerivation rec {
+      pdutil = stdenv.mkDerivation {
         name = "pdutil-${version}";
         src = playdateSDK;
         nativeBuildInputs = [ autoPatchelfHook ];
@@ -47,7 +47,7 @@
           platforms = platforms.linux;
         };
       };
-      PlaydateSimulator = stdenv.mkDerivation rec {
+      PlaydateSimulator = stdenv.mkDerivation {
         name = "PlaydateSimulator-${version}";
         src = playdateSDK;
         nativeBuildInputs = [ autoPatchelfHook ];


### PR DESCRIPTION
This PR fixes the indentation inconsistencies inside the `shellHook`s and adds `\n` to the last message so that the terminal prompt
correctly starts on the next line.

It also removes the unused `rec`s for the objects that are not recursive. 